### PR TITLE
Fix soft-lock by raising an error when input image dimensions unsupported

### DIFF
--- a/trt_utilities.py
+++ b/trt_utilities.py
@@ -267,6 +267,13 @@ class Engine:
 
     def __str__(self):
         out = ""
+            
+        # When raising errors in the upscaler, this str() called by comfy's execution.py,
+        # but the engine won't have the attributes required for stringification
+        # If str() also raises an error, comfy gets soft-locked, not running prompts until restarted
+        if not hasattr(self.engine, "num_optimization_profiles") or not hasattr(self.engine, "num_bindings"):
+            return out
+        
         for opt_profile in range(self.engine.num_optimization_profiles):
             for binding_idx in range(self.engine.num_bindings):
                 name = self.engine.get_binding_name(binding_idx)


### PR DESCRIPTION
Added error handling for unsupported import image dimensions, preventing a soft-lock of comfy that requires a complete restart to resolve.
Put engine build dimensions in constants for transparency and easier handling.
Error message example:
![Screenshot 2025-04-28 at 21-52-40 Unsaved Workflow - ComfyUI](https://github.com/user-attachments/assets/632be081-1988-412a-9ac8-d169f74d7b1b)
