### PR TITLE
Reinitialize `Engine.context` after resetting `Engine`

### DIFF
--- a/trt_utilities.py
+++ b/trt_utilities.py
@@ -156,6 +156,7 @@ class Engine:
         del self.tensors
         # self.engine_path = engine_path
 
+        self.context = None
         self.buffers = OrderedDict()
         self.tensors = OrderedDict()
         self.inputs = {}


### PR DESCRIPTION
Since `Engine.reset` deletes the `context` attribute, `__del__` raises the following exception: `AttributeError: 'Engine' object has no attribute 'context'`

This PR fixes `Engine.reset` by reinitializing the `context` attribute to avoid this error.