### PR TITLE
Added 2x and 3x upscale options

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,7 +22,7 @@ class UpscalerTensorrt:
             "required": {
                 "images": ("IMAGE", {"tooltip": f"Images to be upscaled. Resolution must be between {IMAGE_DIM_MIN} and {IMAGE_DIM_MAX} px"}),
                 "upscaler_trt_model": ("UPSCALER_TRT_MODEL", {"tooltip": "Tensorrt model built and loaded"}),
-                "resize_to": (["none", "HD", "FHD", "2k", "4k"],{"tooltip": "Resize the upscaled image to fixed resolutions, optional"}),
+                "resize_to": (["none", "HD", "FHD", "2k", "4k", "2x", "3x"],{"tooltip": "Resize the upscaled image to fixed resolutions, optional"}),
             }
         }
     RETURN_NAMES = ("IMAGE",)

--- a/utilities.py
+++ b/utilities.py
@@ -121,11 +121,17 @@ def get_final_resolutions(width, height, resize_to):
         case "none":
             final_width = width*4
             final_height = height*4
+        case "2x":
+            final_width = width*2
+            final_height = height*2
+        case "3x":
+            final_width = width*3
+            final_height = height*3
 
     if aspect_ratio == 1.0:
         final_width = final_height
 
-    if aspect_ratio < 1.0 and resize_to != "none":
+    if aspect_ratio < 1.0 and resize_to not in ("none", "2x", "3x"):
         temp = final_width
         final_width = final_height
         final_height = temp


### PR DESCRIPTION
A new options for upscale dimensions of 2x and 3x the original image dimensions. 
Tested on, w1024 * h768 and w720 * h960 dimensions to confirm both width and height are output as expected.