### PR TITLE
1x upscaler support plus new 1x-ITF-SkinDiffDetail-Lite-v1 upscaler

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,7 +24,7 @@ def get_scale_factor_from_model_name(model_name: str) -> int:
     elif "1x" in lower_name or "x1" in lower_name:
         return 1
     else:
-        return 1  # Default
+        return 4  # Default
 
 # --- Function to load configuration ---
 def load_node_config(config_filename="load_upscaler_config.json"):

--- a/load_upscaler_config.json
+++ b/load_upscaler_config.json
@@ -11,7 +11,8 @@
       "4xNomos2_otf_esrgan",
       "4x_UniversalUpscalerV2-Neutral_115000_swaG",
       "4x-ClearRealityV1",
-      "4x-UltraSharpV2_Lite"
+      "4x-UltraSharpV2_Lite",
+      "1x-ITF-SkinDiffDetail-Lite-v1"
     ],
     "default": "4x-UltraSharp",
     "tooltip": "These models have been tested with tensorrt. Loaded from config."


### PR DESCRIPTION
Last time, the 1x-ITF-SkinDiffDetail-Lite-v1 upscaler didn’t work because the `__init__.py` file only supported 4x upscalers. I have now made it dynamic to handle different scale factors. Please note, I’m not a professional Python developer. This is actually the first Python code I have ever written. Feel free to improve the code.

Also, the previous 1x-ITF-SkinDiffDetail-Lite-v1.onnx file I uploaded to the Hugging Face project was incorrect because I didn’t set the scale factor to 1 during the `.pth` to `.onnx` conversion. Here is the updated version:
https://huggingface.co/yuvraj108c/ComfyUI-Upscaler-Onnx/discussions/6