### PR TITLE
1x upscaler support plus new 1x-ITF-SkinDiffDetail-Lite-v1 upscaler

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,6 +16,16 @@ IMAGE_DIM_MIN = 256
 IMAGE_DIM_OPT = 512
 IMAGE_DIM_MAX = 1280
 
+# --- Function to determine scaling factor from model name ---
+def get_scale_factor_from_model_name(model_name: str) -> int:
+    lower_name = model_name.lower()
+    if "4x" in lower_name or "x4" in lower_name:
+        return 4
+    elif "1x" in lower_name or "x1" in lower_name:
+        return 1
+    else:
+        return 4  # Default
+
 # --- Function to load configuration ---
 def load_node_config(config_filename="load_upscaler_config.json"):
     """Loads node configuration from a JSON file."""
@@ -79,11 +89,19 @@ class UpscalerTensorrt:
                 raise ValueError(f"Input image dimensions fall outside of the supported range: {IMAGE_DIM_MIN} to {IMAGE_DIM_MAX} px!\nImage dimensions: {W}px by {H}px")
 
         final_width, final_height = get_final_resolutions(W, H, resize_to)
-        logger.info(f"Upscaling {B} images from H:{H}, W:{W} to H:{H*4}, W:{W*4} | Final resolution: H:{final_height}, W:{final_width} | resize_to: {resize_to}")
+
+        # --- Determination of the scaling factor ---
+        try:
+            scale_factor = get_scale_factor_from_model_name(upscaler_trt_model.model_name)
+        except AttributeError:
+            logger.warning("Attribute ‘model_name’ not found. Default 4x used.")
+            scale_factor = 4
+
+        logger.info(f"Upscaling {B} images from H:{H}, W:{W} to H:{H*scale_factor}, W:{W*scale_factor} | Final resolution: H:{final_height}, W:{final_width} | resize_to: {resize_to}")
 
         shape_dict = {
             "input": {"shape": (1, 3, H, W)},
-            "output": {"shape": (1, 3, H*4, W*4)},
+            "output": {"shape": (1, 3, H*scale_factor, W*scale_factor)},
         }
         upscaler_trt_model.activate()
         upscaler_trt_model.allocate_buffers(shape_dict=shape_dict)
@@ -93,7 +111,7 @@ class UpscalerTensorrt:
         images_list = list(torch.split(images_bchw, split_size_or_sections=1))
 
         upscaled_frames = torch.empty((B, C, final_height, final_width), dtype=torch.float32, device=mm.intermediate_device())
-        must_resize = W*4 != final_width or H*4 != final_height
+        must_resize = W*scale_factor != final_width or H*scale_factor != final_height
 
         for i, img in enumerate(images_list):
             result = upscaler_trt_model.infer({"input": img}, cudaStream)
@@ -187,6 +205,9 @@ class LoadUpscalerTensorrtModel:
         mm.soft_empty_cache()
         engine = Engine(tensorrt_model_path)
         engine.load()
+
+        # --- Save model name for later access ---
+        engine.model_name = model
 
         return (engine,)
 

--- a/load_upscaler_config.json
+++ b/load_upscaler_config.json
@@ -11,7 +11,8 @@
       "4xNomos2_otf_esrgan",
       "4x_UniversalUpscalerV2-Neutral_115000_swaG",
       "4x-ClearRealityV1",
-      "4x-UltraSharpV2_Lite"
+      "4x-UltraSharpV2_Lite",
+      "1x-ITF-SkinDiffDetail-Lite-v1"
     ],
     "default": "4x-UltraSharp",
     "tooltip": "These models have been tested with tensorrt. Loaded from config."


### PR DESCRIPTION
Last time, the 1x-ITF-SkinDiffDetail-Lite-v1 upscaler didn’t work because the `__init__.py` file only supported 4x upscalers. I have now made it dynamic to handle different scale factors. Please note, I’m not a professional Python developer. This is actually the first Python code I have ever written. Feel free to improve the code.

Also, the previous 1x-ITF-SkinDiffDetail-Lite-v1.onnx file I uploaded to the Hugging Face project was incorrect because I didn’t set the scale factor to 1 during the `.pth` to `.onnx` conversion. Here is the updated version:
https://huggingface.co/yuvraj108c/ComfyUI-Upscaler-Onnx/discussions/6