### PR TITLE
Add support for TensorRT-RTX

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -183,7 +183,7 @@ class LoadUpscalerTensorrtModel:
             engine = Engine(tensorrt_model_path)
             engine.build(
                 onnx_path=onnx_model_path,
-                fp16= True if precision == "fp16" else False,
+                fp16= True if precision == "fp16" and not TENSORRT_RTX_AVAILABLE else False,
                 input_profile=[
                     {"input": [(engine_min_batch,engine_channel,engine_min_h,engine_min_w), (engine_opt_batch,engine_channel,engine_opt_h,engine_min_w), (engine_max_batch,engine_channel,engine_max_h,engine_max_w)]},
                 ],

--- a/__init__.py
+++ b/__init__.py
@@ -7,8 +7,14 @@ from .trt_utilities import Engine
 from .utilities import download_file, ColoredLogger, get_final_resolutions
 import comfy.model_management as mm
 import time
-import tensorrt
 import json # <--- Import json module
+
+# Support TensorRT-RTX
+import importlib
+if importlib.util.find_spec('tensorrt_rtx') is not None:
+    import tensorrt_rtx as tensorrt
+else:
+    import tensorrt
 
 logger = ColoredLogger("ComfyUI-Upscaler-Tensorrt")
 

--- a/__init__.py
+++ b/__init__.py
@@ -10,9 +10,11 @@ import time
 import json # <--- Import json module
 
 # Support TensorRT-RTX
+TENSORRT_RTX_AVAILABLE = False
 import importlib
 if importlib.util.find_spec('tensorrt_rtx') is not None:
     import tensorrt_rtx as tensorrt
+    TENSORRT_RTX_AVAILABLE = True
 else:
     import tensorrt
 
@@ -165,7 +167,7 @@ class LoadUpscalerTensorrtModel:
         engine_min_batch, engine_opt_batch, engine_max_batch = 1, 1, 1
         engine_min_h, engine_opt_h, engine_max_h = IMAGE_DIM_MIN, IMAGE_DIM_OPT, IMAGE_DIM_MAX
         engine_min_w, engine_opt_w, engine_max_w = IMAGE_DIM_MIN, IMAGE_DIM_OPT, IMAGE_DIM_MAX
-        tensorrt_model_path = os.path.join(tensorrt_models_dir, f"{model}_{precision}_{engine_min_batch}x{engine_channel}x{engine_min_h}x{engine_min_w}_{engine_opt_batch}x{engine_channel}x{engine_opt_h}x{engine_opt_w}_{engine_max_batch}x{engine_channel}x{engine_max_h}x{engine_max_w}_{tensorrt.__version__}.trt")
+        tensorrt_model_path = os.path.join(tensorrt_models_dir, f"{model}_{precision if not TENSORRT_RTX_AVAILABLE else 'rtx'}_{engine_min_batch}x{engine_channel}x{engine_min_h}x{engine_min_w}_{engine_opt_batch}x{engine_channel}x{engine_opt_h}x{engine_opt_w}_{engine_max_batch}x{engine_channel}x{engine_max_h}x{engine_max_w}_{tensorrt.__version__}.trt")
 
         if not os.path.exists(tensorrt_model_path):
             if not os.path.exists(onnx_model_path):

--- a/trt_utilities.py
+++ b/trt_utilities.py
@@ -29,7 +29,14 @@ from polygraphy.backend.trt import (
     save_engine,
 )
 from polygraphy.logger import G_LOGGER
-import tensorrt as trt
+
+# Support TensorRT-RTX
+import importlib
+if importlib.util.find_spec('tensorrt_rtx') is not None:
+    import tensorrt_rtx as trt
+else:
+    import tensorrt as trt
+
 from logging import error, warning
 from tqdm import tqdm
 import copy

--- a/trt_utilities.py
+++ b/trt_utilities.py
@@ -31,9 +31,11 @@ from polygraphy.backend.trt import (
 from polygraphy.logger import G_LOGGER
 
 # Support TensorRT-RTX
+TENSORRT_RTX_AVAILABLE = False
 import importlib
 if importlib.util.find_spec('tensorrt_rtx') is not None:
     import tensorrt_rtx as trt
+    TENSORRT_RTX_AVAILABLE = True
 else:
     import tensorrt as trt
 
@@ -203,7 +205,8 @@ class Engine:
         config = builder.create_builder_config()
         config.progress_monitor = TQDMProgressMonitor()
 
-        config.set_flag(trt.BuilderFlag.FP16) if fp16 else None
+        # TensorRT-RTX only allows strongly typed networks, so precision is dependent on the model
+        config.set_flag(trt.BuilderFlag.FP16) if fp16 and not TENSORRT_RTX_AVAILABLE else None
         config.set_flag(trt.BuilderFlag.REFIT) if enable_refit else None
 
         profiles = copy.deepcopy(p)


### PR DESCRIPTION
This PR adds support for [TensorRT-RTX](https://docs.nvidia.com/deeplearning/tensorrt-rtx/latest/index.html), a drop-in replacement for TensorRT. TensorRT-RTX itself has mostly the same API while being a lighter and faster library, and is built mainly for consumer-grade RTX GPUs (e.g. 5090).

Notable changes are as follows:
* "FP16" can't be set on RTX engines. The API does not allow that due to only supporting strongly-typed networks, so the precision is dependent on the model being converted.
* Building and loading RTX engines can't be done with Polygraphy due to incompatibilities (Polygraphy doesn't recognize TensorRT-RTX), so this is done the way NVIDIA does it.
  * This could apply to TensorRT engines too, since using the Polygraphy API isn't explicitly required.

TensorRT is still used if TensorRT-RTX is unavailable. To differentiate between engines, RTX engines have `rtx` in their names in place of where precision should be.

Runtime performance is more-or-less the same, but building performance is much better with TensorRT-RTX (tested with [this script](https://gist.github.com/tangalbert919/1b582c9133ab1b23b19818cdb2387b53) on a 5070 on Windows 11):
| Model Name | TensorRT Time | TensorRT-RTX Time |
|--|--|--|
| 4x-AnimeSharp | Failed (OOM) | 8.12s |
| 4x-UltraSharp | Failed (OOM) | 8.11s |
| 4x-UltraSharpV2_Lite | 48.79s | 4.17s |
| 2x-AnimeSharpV3 (imported manually) | 61.92s | 9.02s |
