### PR TITLE
TensorRT 11 hotfixes

### DIFF
--- a/nodes/load_tensorrt_model.py
+++ b/nodes/load_tensorrt_model.py
@@ -70,6 +70,9 @@ class LoadUpscalerTensorrtModel:
                 mm.soft_empty_cache()
                 s = time.time()
                 engine = Engine(tensorrt_model_path)
+                if precision == "fp16" and (TENSORRT_RTX_AVAILABLE or trt.__version__ >= "11.0.0"):
+                    logger.info("TensorRT-RTX or TensorRT 11.0.0 detected. Converting ONNX to fp16")
+                    onnx_model_path = engine.convert_to_fp16(onnx_model_path)
                 engine.build(
                     onnx_path=onnx_model_path,
                     fp16= True if precision == "fp16" and not TENSORRT_RTX_AVAILABLE else False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 tensorrt
 polygraphy
 requests
+onnx
+nvidia-modelopt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ tensorrt
 polygraphy
 requests
 onnx
-nvidia-modelopt
+onnxruntime-gpu
+nvidia-modelopt[all]

--- a/trt_utilities.py
+++ b/trt_utilities.py
@@ -29,6 +29,8 @@ from polygraphy.backend.trt import (
     save_engine,
 )
 from polygraphy.logger import G_LOGGER
+import modelopt.onnx.autocast as autocast
+import onnx
 
 # Support TensorRT-RTX
 TENSORRT_RTX_AVAILABLE = False
@@ -170,6 +172,16 @@ class Engine:
         self.tensors = OrderedDict()
         self.inputs = {}
         self.outputs = {}
+    
+    def convert_to_fp16(self, onnx_path):
+        converted_model = autocast.convert_to_mixed_precision(
+            onnx_path=onnx_path,
+            low_precision_dtype="fp16",
+            keep_io_types=True
+        )
+        onnx_fp16_path = onnx_path.replace(".onnx", "_fp16.onnx")
+        onnx.save(converted_model, onnx_fp16_path)
+        return onnx_fp16_path
 
     def build(
         self,

--- a/trt_utilities.py
+++ b/trt_utilities.py
@@ -214,7 +214,7 @@ class Engine:
         config.progress_monitor = TQDMProgressMonitor()
 
         # TensorRT-RTX only allows strongly typed networks, so precision is dependent on the model
-        config.set_flag(trt.BuilderFlag.FP16) if fp16 and not TENSORRT_RTX_AVAILABLE else None
+        config.set_flag(trt.BuilderFlag.FP16) if fp16 and not (TENSORRT_RTX_AVAILABLE or trt.__version__ >= "11.0.0") else None
         config.set_flag(trt.BuilderFlag.REFIT) if enable_refit else None
 
         profiles = copy.deepcopy(p)


### PR DESCRIPTION
TensorRT 11 removed precision-enabling builder flags and weak typing, so if we want to keep doing FP16 precision, we have to convert the ONNX models we use to FP16 first. More information can be found [here](https://docs.nvidia.com/deeplearning/tensorrt/latest/api/migration/tensorrt-10x-to-11x-python-api.html).